### PR TITLE
Add ability to set scan shifts

### DIFF
--- a/polylaue/model/scan.py
+++ b/polylaue/model/scan.py
@@ -1,0 +1,28 @@
+from polylaue.model.serializable import Serializable
+
+
+class Scan(Serializable):
+    def __init__(
+        self,
+        shift_x: int = 0,
+        shift_y: int = 0,
+        parent: Serializable | None = None,
+    ):
+        self.shift_x = shift_x
+        self.shift_y = shift_y
+        self.parent = parent
+
+    @property
+    def number(self) -> int:
+        # This is based upon the scan info from the parent
+        series = self.parent
+        if series is None:
+            return -1
+
+        return series.scan_number(self)
+
+    # Serialization code
+    _attrs_to_serialize = [
+        'shift_x',
+        'shift_y',
+    ]

--- a/polylaue/ui/project_navigator/dialog.py
+++ b/polylaue/ui/project_navigator/dialog.py
@@ -44,7 +44,7 @@ class ProjectNavigatorDialog(QDialog):
         # Can we come up with something without hard-coding, though?
         self.resize(600, 300)
 
-        self.on_selection_changed()
+        self.update_enable_states()
 
         self.setup_connections()
 
@@ -52,8 +52,9 @@ class ProjectNavigatorDialog(QDialog):
         self.add_button.clicked.connect(self.on_add_clicked)
         self.remove_button.clicked.connect(self.on_remove_clicked)
         self.view.selectionModel().selectionChanged.connect(
-            self.on_selection_changed
+            self.update_enable_states
         )
+        self.view.path_changed.connect(self.update_enable_states)
 
     def on_add_clicked(self):
         self.view.insert_row(-1)
@@ -61,9 +62,12 @@ class ProjectNavigatorDialog(QDialog):
     def on_remove_clicked(self):
         self.view.remove_selected_rows()
 
-    def on_selection_changed(self):
+    def update_enable_states(self):
         num_rows_selected = len(self.view.selected_rows)
-        self.remove_button.setEnabled(num_rows_selected > 0)
+        is_scans = self.view.is_submodel_scans
+
+        self.add_button.setEnabled(not is_scans)
+        self.remove_button.setEnabled(not is_scans and num_rows_selected > 0)
 
     @property
     def layout(self):

--- a/polylaue/ui/project_navigator/model.py
+++ b/polylaue/ui/project_navigator/model.py
@@ -12,6 +12,7 @@ from polylaue.model.project_manager import ProjectManager
 from polylaue.ui.project_navigator.submodels import (
     BaseSubmodel,
     ProjectsSubmodel,
+    ScansSubmodel,
     SectionsSubmodel,
     SeriesSubmodel,
 )
@@ -26,6 +27,7 @@ class ProjectNavigatorModel(QAbstractTableModel):
     2. Project
     3. Section
     4. Series
+    5. Scan
 
     The ProjectNavigatorModel shares some characteristics of a file system
     model, but also contains some differences. Notably, each tier has a
@@ -145,4 +147,5 @@ SUBMODELS = [
     ProjectsSubmodel,
     SectionsSubmodel,
     SeriesSubmodel,
+    ScansSubmodel,
 ]

--- a/polylaue/ui/project_navigator/submodels/__init__.py
+++ b/polylaue/ui/project_navigator/submodels/__init__.py
@@ -1,11 +1,13 @@
 from .base import BaseSubmodel
 from .projects import ProjectsSubmodel
+from .scans import ScansSubmodel
 from .sections import SectionsSubmodel
 from .series import SeriesSubmodel
 
 __all__ = [
     'BaseSubmodel',
     'ProjectsSubmodel',
+    'ScansSubmodel',
     'SectionsSubmodel',
     'SeriesSubmodel',
 ]

--- a/polylaue/ui/project_navigator/submodels/scans.py
+++ b/polylaue/ui/project_navigator/submodels/scans.py
@@ -1,0 +1,29 @@
+from polylaue.model.scan import Scan
+from polylaue.model.series import Series
+from polylaue.ui.project_navigator.submodels.base import BaseSubmodel
+
+
+class ScansSubmodel(BaseSubmodel):
+    type = 'scans'
+
+    def __init__(self, series: Series):
+        self.series = series
+
+    @property
+    def entry_list(self) -> list[Scan]:
+        return self.series.scans
+
+    def create(self) -> Scan:
+        return Scan(parent=self.series)
+
+    @property
+    def columns(self) -> dict[str, str]:
+        return {
+            'number': 'Number',
+            'shift_x': 'Shift X',
+            'shift_y': 'Shift Y',
+        }
+
+    @property
+    def uneditable_column_keys(self) -> list[str]:
+        return ['number']

--- a/polylaue/ui/project_navigator/submodels/series.py
+++ b/polylaue/ui/project_navigator/submodels/series.py
@@ -18,7 +18,6 @@ class SeriesSubmodel(BaseSubmodel):
 
     @property
     def columns(self) -> dict[str, str]:
-        # FIXME: there should potentially be more for series
         return {
             'name': 'Name',
             'description': 'Description',


### PR DESCRIPTION
Setting the scan shifts currently does not do anything. However, it will be needed in the future. We are adding the UI to set them. "Scan Shifts" now appears in the context menu for right-clicking a series.