### PR TITLE
Update mapping when series changes

### DIFF
--- a/polylaue/ui/main_window.py
+++ b/polylaue/ui/main_window.py
@@ -255,6 +255,7 @@ class MainWindow:
         # Load this series without resetting the settings
         self.load_series(new_series, reset_settings=False)
         self.scan_num = new_scan_idx
+        self.on_series_or_scan_changed()
         self.on_frame_changed()
 
     def on_shift_scan_position(self, i: int, j: int):


### PR DESCRIPTION
The code here is changing series when "Page Up" or "Page Down" is used, and the desired scan number is located in a different series. In this case, the series is changed as well as the scan number, and the mapping needs to be updated.