### PR TITLE
Add ability to set background image for a series

### DIFF
--- a/polylaue/ui/resources/ui/series_editor.ui
+++ b/polylaue/ui/resources/ui/series_editor.ui
@@ -7,36 +7,32 @@
     <x>0</x>
     <y>0</y>
     <width>358</width>
-    <height>176</height>
+    <height>204</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Series Editor</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0" colspan="2">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QLabel" name="series_dir_label">
-       <property name="text">
-        <string>Directory:</string>
-       </property>
-       <property name="buddy">
-        <cstring>series_dir</cstring>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLineEdit" name="series_dir"/>
-     </item>
-     <item>
-      <widget class="QPushButton" name="select_series_dir">
-       <property name="text">
-        <string>Select</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+   <item row="3" column="1">
+    <widget class="QSpinBox" name="skip_frames">
+     <property name="maximum">
+      <number>10000</number>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0" colspan="2">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
    <item row="2" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout_3">
@@ -106,19 +102,6 @@
      </item>
     </layout>
    </item>
-   <item row="7" column="0" colspan="2">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
    <item row="3" column="0">
     <widget class="QLabel" name="skip_frames_label">
      <property name="text">
@@ -129,12 +112,53 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
-    <widget class="QSpinBox" name="skip_frames">
-     <property name="maximum">
-      <number>10000</number>
-     </property>
-    </widget>
+   <item row="0" column="0" colspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="series_dir_label">
+       <property name="text">
+        <string>Directory:</string>
+       </property>
+       <property name="buddy">
+        <cstring>series_dir</cstring>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="series_dir"/>
+     </item>
+     <item>
+      <widget class="QPushButton" name="select_series_dir">
+       <property name="text">
+        <string>Select</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="4" column="0" colspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <item>
+      <widget class="QLabel" name="background_image_label">
+       <property name="text">
+        <string>Background image:</string>
+       </property>
+       <property name="buddy">
+        <cstring>background_image</cstring>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="background_image"/>
+     </item>
+     <item>
+      <widget class="QPushButton" name="select_background_image">
+       <property name="text">
+        <string>Select</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>
@@ -146,6 +170,8 @@
   <tabstop>scan_range_start</tabstop>
   <tabstop>scan_range_stop</tabstop>
   <tabstop>skip_frames</tabstop>
+  <tabstop>background_image</tabstop>
+  <tabstop>select_background_image</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/polylaue/ui/series_editor.py
+++ b/polylaue/ui/series_editor.py
@@ -29,6 +29,8 @@ class SeriesEditor:
 
     def setup_connections(self):
         self.ui.select_series_dir.clicked.connect(self.select_series_dir)
+        self.ui.select_background_image.clicked.connect(
+            self.select_background_image_path)
 
     def serialize_series_ui(self) -> dict:
         # Serialize UI settings into a dict
@@ -38,6 +40,7 @@ class SeriesEditor:
             'scan_shape': self.ui_scan_shape,
             'skip_frames': self.ui.skip_frames.value(),
             'scan_range_tuple': self.ui_scan_range,
+            'background_image_path_str': self.ui_background_image,
         }
 
     def update_ui(self):
@@ -51,6 +54,9 @@ class SeriesEditor:
             'scan_shape': lambda v: setattr(self, 'ui_scan_shape', v),
             'skip_frames': self.ui.skip_frames.setValue,
             'scan_range_tuple': lambda v: setattr(self, 'ui_scan_range', v),
+            'background_image_path_str': lambda v: (
+                setattr(self, 'ui_background_image', v),
+            ),
         }
         for k, v in d.items():
             if k in setters:
@@ -76,6 +82,19 @@ class SeriesEditor:
 
         self.ui.series_dir.setText(selected_directory)
 
+    def select_background_image_path(self):
+        selected_file, selected_filter = QFileDialog.getOpenFileName(
+            self.ui,
+            'Select Background Image',
+            self.ui.background_image.text(),
+        )
+
+        if not selected_file:
+            # User canceled
+            return
+
+        self.ui.background_image.setText(selected_file)
+
     # UI properties that match config properties
     @property
     def ui_scan_shape(self) -> tuple[int, int]:
@@ -100,6 +119,16 @@ class SeriesEditor:
     def ui_scan_range(self, v: tuple[int, int]):
         self.ui.scan_range_start.setValue(v[0])
         self.ui.scan_range_stop.setValue(v[1])
+
+    @property
+    def ui_background_image(self) -> str | None:
+        t = self.ui.background_image.text()
+        return t if t else None
+
+    @ui_background_image.setter
+    def ui_background_image(self, v: str | None):
+        t = v if v else ''
+        self.ui.background_image.setText(t)
 
 
 class SeriesEditorDialog(QDialog):


### PR DESCRIPTION
This adds the basic ability to set the background image for a series.

This will be improved upon further, such as adding the ability to set the current image in the display to be the background image for either the series or a whole section.

We will also add a checkbox to enable/disable background subtraction.

Fixes: #13