### PR TITLE
Add additional background subtraction settings

### DIFF
--- a/polylaue/ui/image_view.py
+++ b/polylaue/ui/image_view.py
@@ -54,8 +54,9 @@ class PolyLaueImageView(pg.ImageView):
         self.addItem(artist)
         self.reflection_status_message = ''
 
-        # Add an action to reverse the cmap
-        self.add_cmap_reverse_menu_action()
+        # Add additional context menu actions
+        self.add_additional_cmap_menu_actions()
+        self.add_additional_histogram_menu_actions()
 
         self.setup_connections()
 
@@ -324,7 +325,7 @@ class PolyLaueImageView(pg.ImageView):
 
         return super().keyPressEvent(event)
 
-    def add_cmap_reverse_menu_action(self):
+    def add_additional_cmap_menu_actions(self):
         """Add a 'reverse' action to the pyqtgraph colormap menu
 
         This assumes pyqtgraph won't change its internal attribute structure.
@@ -353,3 +354,32 @@ class PolyLaueImageView(pg.ImageView):
         menu.addSeparator()
         action = menu.addAction('reverse')
         action.triggered.connect(reverse)
+
+    def add_additional_histogram_menu_actions(self):
+        """Add a 'auto level' action to the pyqtgraph histogram menu
+
+        This assumes pyqtgraph won't change its internal attribute structure.
+        If it does change, then this function just won't work...
+        """
+        w = self.getHistogramWidget()
+        if not w:
+            # There should be a histogram widget. Not sure why it's missing...
+            return
+
+        try:
+            vb = w.item.vb
+            menu = vb.menu
+        except AttributeError:
+            # pyqtgraph must have changed its attribute structure
+            return
+
+        if not menu:
+            return
+
+        def auto_level():
+            self.auto_level_colors()
+            self.auto_level_histogram_range()
+
+        menu.addSeparator()
+        action = menu.addAction('auto level')
+        action.triggered.connect(auto_level)

--- a/polylaue/ui/region_mapping/dialog.py
+++ b/polylaue/ui/region_mapping/dialog.py
@@ -80,8 +80,8 @@ DEFAULT_ROI_ITEM_ARGS = {
 
 SHOW_HIGHLIGHT_MSG = 'Show Highlight Region'
 HIDE_HIGHLIGHT_MSG = 'Hide Highlight Region'
-SHOW_DOMAIN_MSG = 'Show Mapping Domain'
-HIDE_DOMAIN_MSG = 'Hide Mapping Domain'
+SHOW_DOMAIN_MSG = 'Show Map Shape'
+HIDE_DOMAIN_MSG = 'Hide Map Shape'
 
 
 class RegionMappingDialog(QDialog):

--- a/polylaue/ui/resources/ui/main_window.ui
+++ b/polylaue/ui/resources/ui/main_window.ui
@@ -75,11 +75,18 @@
     </property>
     <addaction name="action_select_indexing_points"/>
    </widget>
+   <widget class="QMenu" name="menu_settings">
+    <property name="title">
+     <string>Settings</string>
+    </property>
+    <addaction name="action_apply_background_subtraction"/>
+   </widget>
    <addaction name="menu_file"/>
    <addaction name="menu_projects"/>
    <addaction name="menu_overlays"/>
    <addaction name="menu_mapping"/>
    <addaction name="menu_indexing"/>
+   <addaction name="menu_settings"/>
   </widget>
   <widget class="QStatusBar" name="status_bar"/>
   <action name="action_open_series">
@@ -115,6 +122,17 @@
   <action name="action_select_indexing_points">
    <property name="text">
     <string>Select Points</string>
+   </property>
+  </action>
+  <action name="action_apply_background_subtraction">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Apply Background Subtraction</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
This adds the ability to right-click the image view and set the current
image as the background for either the series or the entire section.

It also adds the ability to auto-level the histogram.

And, it adds the ability to toggle on/off background subtraction for the
view (it is enabled by default).
