### PR TITLE
Fix disappearing "set as background" context menu option

### DIFF
--- a/polylaue/ui/image_view.py
+++ b/polylaue/ui/image_view.py
@@ -331,6 +331,22 @@ class PolyLaueImageView(pg.ImageView):
 
         return super().keyPressEvent(event)
 
+    @property
+    def context_menu_enabled(self) -> bool:
+        return self.view.menuEnabled()
+
+    @context_menu_enabled.setter
+    def context_menu_enabled(self, b: bool):
+        prev = self.view.menuEnabled()
+        if b == prev:
+            # Nothing to do
+            return
+
+        self.view.setMenuEnabled(b)
+        if b and not prev:
+            # The menu got re-created. Re-create our custom menu items.
+            self.add_additional_image_view_menu_actions()
+
     def add_additional_context_menu_actions(self):
         self.add_additional_image_view_menu_actions()
         self.add_additional_cmap_menu_actions()

--- a/polylaue/ui/point_selector.py
+++ b/polylaue/ui/point_selector.py
@@ -40,8 +40,8 @@ class PointSelector(QObject):
         image_view.addItem(artist)
 
         # Disable the context menu while this is active
-        self._prev_menu_enabled = image_view.view.menuEnabled()
-        image_view.view.setMenuEnabled(False)
+        self._prev_menu_enabled = image_view.context_menu_enabled
+        image_view.context_menu_enabled = False
 
         self.setup_connections()
 
@@ -57,7 +57,7 @@ class PointSelector(QObject):
             self.scatter_artist = None
 
         if self.image_view:
-            self.image_view.view.setMenuEnabled(self._prev_menu_enabled)
+            self.image_view.context_menu_enabled = self._prev_menu_enabled
             self.image_view.scene.sigMouseClicked.disconnect(
                 self._mouse_click_connection
             )


### PR DESCRIPTION
This option would disappear when the context menu would get re-created.

Add properties on the image view that take into account this and fix the issue.

Fixes: #23