### PR TITLE
Add angular shift tracking for crystals

### DIFF
--- a/polylaue/model/core/__init__.py
+++ b/polylaue/model/core/__init__.py
@@ -1,5 +1,6 @@
 # Copyright © 2024, UChicago Argonne, LLC. See "LICENSE" for full details.
 
+from .angular_shift import apply_angular_shift, compute_angular_shift
 from .burn_reflections import burn, VALID_STRUCTURE_TYPES
 from .find import find, find_py
 from .track import track, track_py

--- a/polylaue/model/core/angular_shift.py
+++ b/polylaue/model/core/angular_shift.py
@@ -1,0 +1,36 @@
+# Copyright © 2024, UChicago Argonne, LLC. See "LICENSE" for full details.
+
+import numpy as np
+
+
+def compute_angular_shift(
+    abc_matrix0: np.ndarray,
+    abc_matrix: np.ndarray,
+) -> np.ndarray:
+    a1 = abc_matrix[6:9] / np.sqrt(np.sum(abc_matrix[6:9] ** 2))
+    a2 = np.cross(abc_matrix[3:6], abc_matrix[6:9])
+    a2 = a2 / np.sqrt(np.sum(a2**2))
+    a3 = np.cross(a1, a2)
+    unmov = np.vstack((a1, a2, a3))
+    a1 = abc_matrix0[6:9] / np.sqrt(np.sum(abc_matrix0[6:9] ** 2))
+    a2 = np.cross(abc_matrix0[3:6], abc_matrix0[6:9])
+    a2 = a2 / np.sqrt(np.sum(a2**2))
+    a3 = np.cross(a1, a2)
+    mov = np.hstack(
+        (
+            np.expand_dims(a1, axis=1),
+            np.expand_dims(a2, axis=1),
+            np.expand_dims(a3, axis=1),
+        )
+    )
+    ten = mov @ unmov
+    return ten.reshape(9)
+
+
+def apply_angular_shift(
+    abc_matrix: np.ndarray,
+    angular_shift: np.ndarray,
+) -> np.ndarray:
+    a = abc_matrix.reshape(3, -1)
+    ten = angular_shift.reshape(3, -1)
+    return (a @ ten).flatten()

--- a/polylaue/model/core/track.py
+++ b/polylaue/model/core/track.py
@@ -11,7 +11,7 @@ def track(
     beam_dir: np.ndarray,
     pix_dist: np.ndarray,
     ang_tol: float = 0.07,
-    ang_lim: float = 29.,
+    ang_lim: float = 29.0,
     res_lim: float = 0.3,
     ref_thr: int = 3,
 ) -> np.ndarray | None:

--- a/polylaue/ui/burn_dialog.py
+++ b/polylaue/ui/burn_dialog.py
@@ -13,6 +13,7 @@ class BurnDialog(QObject):
     overwrite_crystal = Signal()
     crystal_name_modified = Signal()
     load_crystal_name = Signal()
+    update_angular_shift_state = Signal()
     write_crystal_orientation = Signal()
     clear_reflections = Signal()
 
@@ -23,8 +24,9 @@ class BurnDialog(QObject):
 
         self.add_structure_options()
 
+        # Make this the default
+        self.set_crystal_orientation_to_hdf5_file()
         self.update_enable_states()
-
         self.setup_connections()
 
     def add_structure_options(self):
@@ -147,11 +149,12 @@ class BurnDialog(QObject):
 
     @property
     def apply_angular_shift(self) -> bool:
-        return self.ui.apply_angular_shift.isChecked()
+        w = self.ui.apply_angular_shift
+        return w.isEnabled() and w.isChecked()
 
     @apply_angular_shift.setter
     def apply_angular_shift(self, b: bool):
-        self.ui.apply_angularShift.setChecked(b)
+        self.ui.apply_angular_shift.setChecked(b)
 
     def on_activate_burn(self):
         self.emit_if_active()
@@ -165,6 +168,7 @@ class BurnDialog(QObject):
 
         # Load the crystal name
         self.load_crystal_name.emit()
+        self.update_angular_shift_state.emit()
 
     def on_crystal_name_edited(self):
         self.crystal_name_modified.emit()
@@ -173,6 +177,7 @@ class BurnDialog(QObject):
         # Deactivate the burn function
         self.deactivate_burn()
         self.update_enable_states()
+        self.update_angular_shift_state.emit()
 
     def on_overwrite_crystal_clicked(self):
         self.overwrite_crystal.emit()

--- a/polylaue/ui/hkl_regions_navigator/dialog.py
+++ b/polylaue/ui/hkl_regions_navigator/dialog.py
@@ -330,11 +330,11 @@ class HklRegionsNavigatorDialog(QDialog):
         self.remove_roi(id)
 
     def remove_roi(self, id: str):
-         self.model.remove_roi(id)
-         self.roi_items_manager.remove_roi_item(id)
-         self.view.selectionModel().clear()
+        self.model.remove_roi(id)
+        self.roi_items_manager.remove_roi_item(id)
+        self.view.selectionModel().clear()
 
-         self.sigRemoveRoiClicked.emit(id)
+        self.sigRemoveRoiClicked.emit(id)
 
     def remove_all_rois(self):
         for id in list(self.model.roi_manager.rois):

--- a/polylaue/ui/main_window.py
+++ b/polylaue/ui/main_window.py
@@ -482,6 +482,8 @@ class MainWindow(QObject):
             dialog.set_series(self.series)
             dialog.set_scan_number(self.scan_num)
 
+        self.reflections_editor.on_series_or_scan_changed()
+
     def on_hkls_changed(self):
         if hasattr(self, '_hkl_regions_navigator_dialog'):
             d = self._hkl_regions_navigator_dialog
@@ -766,6 +768,16 @@ class MainWindow(QObject):
         if not d.points:
             # No points, just return
             return
+
+        if d.indexing_selected or d.refinement_selected:
+            if len(d.points) < 2:
+                msg = (
+                    'For indexing or refinement, at least 2 points must '
+                    'be picked.'
+                )
+                QMessageBox.critical(self.ui, 'Not enough points', msg)
+                d.show()
+                return
 
         project = self.series.parent.parent
         project_dir = project.directory

--- a/polylaue/ui/point_selector.py
+++ b/polylaue/ui/point_selector.py
@@ -241,8 +241,7 @@ class PointSelectorDialog(QDialog):
         def on_accepted():
             # Add back in the original points
             self.point_selector.points = (
-                original_points +
-                self.point_selector.points
+                original_points + self.point_selector.points
             )
             self.point_selector.points_changed()
 

--- a/polylaue/ui/reflections_editor.py
+++ b/polylaue/ui/reflections_editor.py
@@ -115,6 +115,10 @@ class ReflectionsEditor(QObject):
         if self._burn_workflow is not None:
             self._burn_workflow.on_frame_changed()
 
+    def on_series_or_scan_changed(self):
+        if self._burn_workflow is not None:
+            self._burn_workflow.on_series_or_scan_changed()
+
     @property
     def style(self) -> ReflectionsStyle:
         return self.reflections_style_editor.style

--- a/polylaue/ui/resources/ui/burn_dialog.ui
+++ b/polylaue/ui/resources/ui/burn_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>460</width>
-    <height>540</height>
+    <height>548</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,10 +17,13 @@
    <item row="7" column="0">
     <widget class="QCheckBox" name="apply_angular_shift">
      <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Apply an angular shift to the ABC Matrix.&lt;/p&gt;&lt;p&gt;If checked, the file &amp;quot;ang_shifts.npy&amp;quot; must be present in the root level of the project directory. This file will be loaded, and the current scan number will be used to extract the angular shift from the array.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Apply angular shift to the ABC Matrix.&lt;/p&gt;&lt;p&gt;If checked, the selected crystal ID must have angular shifts for this scan number stored in the reflections HDF5 file. These angular shifts are typically generated using &amp;quot;Indexing&amp;quot; -&amp;gt; &amp;quot;Select Points&amp;quot; -&amp;gt; &amp;quot;Refinement&amp;quot;, to perform crystal orientation tracking.&lt;/p&gt;&lt;p&gt;If this checkbox is disabled, that indicates there are no angular shifts for this scan number in the reflections HDF5 file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="text">
       <string>Apply Angular Shift</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
      </property>
     </widget>
    </item>

--- a/polylaue/ui/resources/ui/find_dialog.ui
+++ b/polylaue/ui/resources/ui/find_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>746</width>
-    <height>314</height>
+    <height>356</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -303,6 +303,19 @@
      </property>
     </spacer>
    </item>
+   <item row="4" column="0">
+    <widget class="QCheckBox" name="apply_angular_shifts_from_first">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the angular shifts of the new crystal to match those from the first crystal.&lt;/p&gt;&lt;p&gt;You wouldn't enable this if you expect your crystals to have different angular shifts (for example, the sample bends such that one crystal has a different angular shift than another crystal).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Apply angular shifts from first crystal?</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -322,6 +335,7 @@
   <tabstop>angular_tolerance</tabstop>
   <tabstop>resolution_limit</tabstop>
   <tabstop>reflections_threshold</tabstop>
+  <tabstop>apply_angular_shifts_from_first</tabstop>
   <tabstop>conserve_memory</tabstop>
  </tabstops>
  <resources/>

--- a/polylaue/ui/resources/ui/track_dialog.ui
+++ b/polylaue/ui/resources/ui/track_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>632</width>
-    <height>272</height>
+    <height>304</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -20,16 +20,91 @@
    <string>Track Orientation</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="4" column="1">
-    <widget class="QSpinBox" name="reflections_threshold">
+   <item row="3" column="0">
+    <widget class="QLabel" name="resolution_limit_label">
      <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The minimum number of indexed reflections to assume the indexing routine was successful.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Default: 3&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Default: 0.4 Å&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Resolution Limit:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="crystal_id_label">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The crystal ID to use as a starting point. The ABC matrix for this crystal will be automatically rotated to determine the best orientation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Crystal ID:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0" colspan="2">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="angular_limit_label">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Default: 29°&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Angular Limit:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="ScientificDoubleSpinBox" name="angular_limit">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Default: 29°&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="suffix">
+      <string>°</string>
+     </property>
+     <property name="decimals">
+      <number>8</number>
      </property>
      <property name="maximum">
-      <number>100000</number>
+      <double>1000000.000000000000000</double>
      </property>
      <property name="value">
-      <number>3</number>
+      <double>29.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="2">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Note: you may still manually add or remove points while this dialog is open.</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="ScientificDoubleSpinBox" name="resolution_limit">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Default: 0.4 Å&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="suffix">
+      <string> Å</string>
+     </property>
+     <property name="decimals">
+      <number>8</number>
+     </property>
+     <property name="maximum">
+      <double>1000000.000000000000000</double>
+     </property>
+     <property name="value">
+      <double>0.400000000000000</double>
      </property>
     </widget>
    </item>
@@ -43,13 +118,33 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="angular_limit_label">
+   <item row="8" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Apply|QDialogButtonBox::Close</set>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QSpinBox" name="reflections_threshold">
      <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Default: 29°&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The minimum number of indexed reflections to assume the indexing routine was successful.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Default: 3&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="maximum">
+      <number>100000</number>
+     </property>
+     <property name="value">
+      <number>3</number>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QCheckBox" name="conserve_memory">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, a different version of the internal function will be utilized that uses less RAM, but also runs a little slower.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="text">
-      <string>Angular Limit:</string>
+      <string>Conserve Memory</string>
      </property>
     </widget>
    </item>
@@ -73,74 +168,6 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
-    <widget class="ScientificDoubleSpinBox" name="angular_limit">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Default: 29°&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="suffix">
-      <string>°</string>
-     </property>
-     <property name="decimals">
-      <number>8</number>
-     </property>
-     <property name="maximum">
-      <double>1000000.000000000000000</double>
-     </property>
-     <property name="value">
-      <double>29.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="crystal_id_label">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The crystal ID to use as a starting point. The ABC matrix for this crystal will be automatically rotated to determine the best orientation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Starting Crystal ID:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="ScientificDoubleSpinBox" name="resolution_limit">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Default: 0.4 Å&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="suffix">
-      <string> Å</string>
-     </property>
-     <property name="decimals">
-      <number>8</number>
-     </property>
-     <property name="maximum">
-      <double>1000000.000000000000000</double>
-     </property>
-     <property name="value">
-      <double>0.400000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="resolution_limit_label">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Default: 0.4 Å&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Resolution Limit:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="QCheckBox" name="conserve_memory">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, a different version of the internal function will be utilized that uses less RAM, but also runs a little slower.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Conserve Memory</string>
-     </property>
-    </widget>
-   </item>
    <item row="1" column="1">
     <widget class="ScientificDoubleSpinBox" name="angular_tolerance">
      <property name="toolTip">
@@ -160,32 +187,18 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="button_box">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Apply|QDialogButtonBox::Close</set>
+   <item row="5" column="0">
+    <widget class="QCheckBox" name="angular_shift_apply_all">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Whether to apply the same angular shift to all crystals for the selected scan number.&lt;/p&gt;&lt;p&gt;You wouldn't enable this if you expect your crystals to have different angular shifts (for example, the sample bends such that one crystal has a different angular shift than another crystal).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
-    </widget>
-   </item>
-   <item row="6" column="0" colspan="2">
-    <widget class="QLabel" name="label">
      <property name="text">
-      <string>Note: you may still manually add or remove points while this dialog is open.</string>
+      <string>Apply angular shift to all crystals?</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
      </property>
     </widget>
-   </item>
-   <item row="8" column="0" colspan="2">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>0</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>
@@ -202,6 +215,7 @@
   <tabstop>angular_limit</tabstop>
   <tabstop>resolution_limit</tabstop>
   <tabstop>reflections_threshold</tabstop>
+  <tabstop>angular_shift_apply_all</tabstop>
   <tabstop>conserve_memory</tabstop>
  </tabstops>
  <resources/>

--- a/polylaue/ui/utils/keep_dialog_on_top.py
+++ b/polylaue/ui/utils/keep_dialog_on_top.py
@@ -1,3 +1,5 @@
+# Copyright © 2024, UChicago Argonne, LLC. See "LICENSE" for full details.
+
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QDialog
 

--- a/tests/test_find.py
+++ b/tests/test_find.py
@@ -28,7 +28,7 @@ def find_kwargs(
     return {
         'obs_xy': indexing_points,
         'energy_highest': 70,
-        'cell_parameters': [4.96, 4.96, 3.09, 90., 90., 120.],
+        'cell_parameters': [4.96, 4.96, 3.09, 90.0, 90.0, 120.0],
         'det_org': test_geometry['det_org'],
         'beam_dir': test_geometry['beam_dir'],
         'pix_dist': test_geometry['pix_dist'],


### PR DESCRIPTION
Now, when track() is performed, instead of creating a whole new 
crystal with its own ABC matrix, we instead determine the angular
shift matrix and store that matrix in the HDF5 file, for that crystal.

The checkbox "Apply angular shift?" in the burn dialog is then used
for applying this angular shift.

Users have the options to re-use angular shifts from the first
crystal when indexing a new crystal, and apply the angular shift
to all crystals when performing tracking.