### PR TITLE
Move scan coordinates to `Series`

### DIFF
--- a/polylaue/model/scan.py
+++ b/polylaue/model/scan.py
@@ -15,61 +15,18 @@ class Scan(Serializable):
         parent: Series,
         shift_x: int = 0,
         shift_y: int = 0,
-        scan_center_params: dict | None = None,
     ):
         self.parent = parent
         self.shift_x = shift_x
         self.shift_y = shift_y
-        self.scan_center_params = scan_center_params
 
     @property
     def number(self) -> int:
         # This is based upon the scan info from the parent
         return self.parent.scan_number(self)
 
-    def compute_position_um(
-        self, scan_pos_y: int, scan_pos_z: int
-    ) -> tuple[float, float] | None:
-        """Compute the physical position in µm for a given scan position.
-
-        The number of points along each axis is obtained from the series
-        scan_shape (rows=Z, columns=Y).
-
-        Returns (y_um, z_um) or None if scan center params are not set.
-        """
-        params = self.scan_center_params
-        if params is None:
-            return None
-
-        center_y = params['center_y']
-        center_z = params['center_z']
-        y_min = params['y_min']
-        y_max = params['y_max']
-        z_min = params['z_min']
-        z_max = params['z_max']
-
-        # scan_shape is (rows, cols) = (z_num_points, y_num_points)
-        scan_shape = self.parent.scan_shape
-        y_num_points = scan_shape[1]
-        z_num_points = scan_shape[0]
-
-        if y_num_points > 1:
-            y_step = (y_max - y_min) / (y_num_points - 1)
-            y_um = center_y + y_min + scan_pos_y * y_step
-        else:
-            y_um = center_y
-
-        if z_num_points > 1:
-            z_step = (z_max - z_min) / (z_num_points - 1)
-            z_um = center_z + z_min + scan_pos_z * z_step
-        else:
-            z_um = center_z
-
-        return (y_um, z_um)
-
     # Serialization code
     _attrs_to_serialize = [
         'shift_x',
         'shift_y',
-        'scan_center_params',
     ]

--- a/polylaue/model/series.py
+++ b/polylaue/model/series.py
@@ -51,6 +51,7 @@ class Series(Editable):
         skip_frames: int | None = None,
         background_image_path: PathLike | None = None,
         file_prefix: str | None = None,
+        scan_center_params: dict | None = None,
     ):
         super().__init__()
 
@@ -83,7 +84,7 @@ class Series(Editable):
             if parent.series:
                 skip_frames = parent.series[-1].skip_frames
             else:
-                skip_frames = 10
+                skip_frames = 0
 
         self.name = name
         self.description = description
@@ -96,6 +97,7 @@ class Series(Editable):
         self.has_final_dark_file = False
         self.file_prefix = file_prefix
         self.file_list = []
+        self.scan_center_params = scan_center_params
         self.parent = parent
 
     @property
@@ -431,6 +433,45 @@ class Series(Editable):
 
         self.background_image_path = v
 
+    def compute_position(
+        self, scan_pos_y: int, scan_pos_z: int
+    ) -> tuple[float, float] | None:
+        """Compute the physical position for a given scan position.
+
+        The number of points along each axis is obtained from the
+        scan_shape (rows=Z, columns=Y).
+
+        Returns (y, z) or None if scan center params are not set.
+        """
+        params = self.scan_center_params
+        if params is None:
+            return None
+
+        center_y = params['center_y']
+        center_z = params['center_z']
+        y_min = params['y_min']
+        y_max = params['y_max']
+        z_min = params['z_min']
+        z_max = params['z_max']
+
+        # scan_shape is (rows, cols) = (z_num_points, y_num_points)
+        y_num_points = self.scan_shape[1]
+        z_num_points = self.scan_shape[0]
+
+        if y_num_points > 1:
+            y_step = (y_max - y_min) / (y_num_points - 1)
+            y_val = center_y + y_min + scan_pos_y * y_step
+        else:
+            y_val = center_y
+
+        if z_num_points > 1:
+            z_step = (z_max - z_min) / (z_num_points - 1)
+            z_val = center_z + z_min + scan_pos_z * z_step
+        else:
+            z_val = center_z
+
+        return (y_val, z_val)
+
     # Serialization code
     _attrs_to_serialize = [
         'name',
@@ -442,6 +483,7 @@ class Series(Editable):
         'skip_frames',
         'file_prefix',
         'background_image_path_str',
+        'scan_center_params',
     ]
 
     @property

--- a/polylaue/ui/main_window.py
+++ b/polylaue/ui/main_window.py
@@ -597,16 +597,14 @@ class MainWindow(QObject):
     def update_position_label(self):
         pos_text = ''
         if self.series is not None:
-            scan = self.current_scan
-            if scan is not None:
-                pos_um = scan.compute_position_um(
-                    int(self.scan_pos[1]), int(self.scan_pos[0])
-                )
-                if pos_um is not None:
-                    y_um, z_um = pos_um
-                    y_str = f'{y_um:.6f}'.rstrip('0').rstrip('.')
-                    z_str = f'{z_um:.6f}'.rstrip('0').rstrip('.')
-                    pos_text = f'Y={y_str} µm, Z={z_str} µm'
+            pos = self.series.compute_position(
+                int(self.scan_pos[1]), int(self.scan_pos[0])
+            )
+            if pos is not None:
+                y_val, z_val = pos
+                y_str = f'{y_val:.6f}'.rstrip('0').rstrip('.')
+                z_str = f'{z_val:.6f}'.rstrip('0').rstrip('.')
+                pos_text = f'Y={y_str}, Z={z_str}'
 
         self.ui.position_label.setText(pos_text)
 
@@ -684,20 +682,13 @@ class MainWindow(QObject):
             QMessageBox.warning(self.ui, 'No Series', 'A series must be loaded first.')
             return
 
-        scan = self.current_scan
-        if scan is None:
-            QMessageBox.warning(
-                self.ui, 'No Scan', 'No scan found for the current position.'
-            )
-            return
-
         dialog = ScanPositionCoordsDialog(self.ui)
-        params = dialog.exec(scan.scan_center_params)
+        params = dialog.exec(self.series.scan_center_params)
         if params is None:
             # User cancelled
             return
 
-        scan.scan_center_params = params
+        self.series.scan_center_params = params
         self.save_project_manager()
         self.update_info_label()
 

--- a/polylaue/ui/resources/ui/main_window.ui
+++ b/polylaue/ui/resources/ui/main_window.ui
@@ -178,7 +178,7 @@
   </action>
   <action name="action_indexing_track">
    <property name="text">
-    <string>Track</string>
+    <string>Track/Refine</string>
    </property>
   </action>
   <action name="action_include_advanced_structures">

--- a/polylaue/ui/resources/ui/scan_position_coords_dialog.ui
+++ b/polylaue/ui/resources/ui/scan_position_coords_dialog.ui
@@ -33,7 +33,7 @@
          <string>Y coordinate of the scan center.</string>
         </property>
         <property name="suffix">
-         <string> µm</string>
+         <string></string>
         </property>
         <property name="keyboardTracking">
          <bool>false</bool>
@@ -62,7 +62,7 @@
          <string>Z coordinate of the scan center.</string>
         </property>
         <property name="suffix">
-         <string> µm</string>
+         <string></string>
         </property>
         <property name="keyboardTracking">
          <bool>false</bool>
@@ -100,7 +100,7 @@
          <string>Minimum Y offset relative to the scan center.</string>
         </property>
         <property name="suffix">
-         <string> µm</string>
+         <string></string>
         </property>
         <property name="keyboardTracking">
          <bool>false</bool>
@@ -129,7 +129,7 @@
          <string>Maximum Y offset relative to the scan center.</string>
         </property>
         <property name="suffix">
-         <string> µm</string>
+         <string></string>
         </property>
         <property name="keyboardTracking">
          <bool>false</bool>
@@ -167,7 +167,7 @@
          <string>Minimum Z offset relative to the scan center.</string>
         </property>
         <property name="suffix">
-         <string> µm</string>
+         <string></string>
         </property>
         <property name="keyboardTracking">
          <bool>false</bool>
@@ -196,7 +196,7 @@
          <string>Maximum Z offset relative to the scan center.</string>
         </property>
         <property name="suffix">
-         <string> µm</string>
+         <string></string>
         </property>
         <property name="keyboardTracking">
          <bool>false</bool>

--- a/polylaue/ui/resources/ui/track_dialog.ui
+++ b/polylaue/ui/resources/ui/track_dialog.ui
@@ -17,7 +17,7 @@
    </sizepolicy>
   </property>
   <property name="windowTitle">
-   <string>Track Orientation</string>
+   <string>Track/Refine Orientation</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="4" column="0" colspan="2">

--- a/tests/test_find.py
+++ b/tests/test_find.py
@@ -7,7 +7,7 @@ import pytest
 
 from polylaue.model.core import find, find_py
 
-from tests.conftest import skip_slow
+from conftest import skip_slow
 
 
 @pytest.fixture

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -60,13 +60,11 @@ class TestScan:
         assert serialized == {
             'shift_x': 5,
             'shift_y': -3,
-            'scan_center_params': None,
         }
 
         new_scan = Scan.from_serialized(serialized, parent=series)
         assert new_scan.shift_x == 5
         assert new_scan.shift_y == -3
-        assert new_scan.scan_center_params is None
 
 
 class TestSeries:

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -7,7 +7,7 @@ import pytest
 
 from polylaue.model.core import track, track_py
 
-from tests.conftest import skip_slow
+from conftest import skip_slow
 
 
 @pytest.fixture


### PR DESCRIPTION
This also makes it unitless (as requested by the users). The user will just need to remember which units they used.

It also sets the default skip frames to 0, and changes the `Track` name to `Track/Refine`.