### PR TITLE
Load newest scan in live acquisition

### DIFF
--- a/polylaue/model/io.py
+++ b/polylaue/model/io.py
@@ -27,6 +27,27 @@ def identify_loader_function(
     return load_file_with_fabio
 
 
+def validate_image_file(path: PathLike) -> bool:
+    """Check whether an image file can be opened.
+
+    This is intentionally lightweight — it reads only the file header,
+    not the full pixel data.  Returns False for missing, empty, or
+    partially-written files.
+    """
+    extension = Path(path).suffix[1:]
+    try:
+        for regex, func in CUSTOM_VALIDATORS.items():
+            if re.match(regex, extension):
+                func(path)
+                return True
+
+        # Default to fabio
+        _validate_with_fabio(path)
+        return True
+    except Exception:
+        return False
+
+
 def load_image_file(path: PathLike, bounds: Optional[Bounds] = None) -> np.ndarray:
     # Automatically identify the file type and load it
     func = identify_loader_function(path)
@@ -99,11 +120,35 @@ def get_file_creation_time(filepath: PathLike) -> float:
     return stats.st_mtime
 
 
-# The key for these custom readers is the regular expression
+def _validate_tif_file(path: PathLike) -> None:
+    """Open a TIF header to verify the file is readable."""
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', UserWarning)
+        Image.open(path).close()
+
+
+def _validate_with_fabio(path: PathLike) -> None:
+    """Open a file with fabio to verify it is readable."""
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        with fabio.open(path):
+            pass
+
+
+# The key for these custom readers/validators is the regular expression
 # that the extension should match.
 CUSTOM_READERS = {
     r'^tiff?$': load_tif_file,
 }
 
+CUSTOM_VALIDATORS = {
+    r'^tiff?$': _validate_tif_file,
+}
+
 # Compile the regular expressions
 CUSTOM_READERS = {re.compile(k): v for k, v in CUSTOM_READERS.items()}
+CUSTOM_VALIDATORS = {re.compile(k): v for k, v in CUSTOM_VALIDATORS.items()}

--- a/polylaue/model/series.py
+++ b/polylaue/model/series.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from polylaue.model.editable import Editable, ParameterDescription
-from polylaue.model.io import get_file_creation_time
+from polylaue.model.io import get_file_creation_time, validate_image_file
 from polylaue.model.scan import Scan
 from polylaue.model.serializable import ValidationError
 from polylaue.typing import PathLike
@@ -288,28 +288,45 @@ class Series(Editable):
         return file_prefix, file_list
 
     @property
-    def has_enough_data_for_new_scan(self) -> bool:
-        # Check if there are enough data files present for a new scan.
-        # This needs to be fast because we will check it multiple times each
-        # second during acquisition.
+    def newest_available_scan_number(self) -> int | None:
+        """Find the newest scan number for which all data files exist.
+
+        Returns the scan number of the newest complete scan beyond the
+        current set, or None if no new complete scan is available.
+        This needs to be fast because it's called during live acquisition.
+        """
         prefix = self.file_prefix
         if not prefix or not self.file_list:
-            return False
+            return None
 
-        # Assume that we will use the same file extension as the other files
         last_file = self.file_list[-1]
         suffix = Path(last_file).suffix
+        scan_size = int(np.prod(self.scan_shape))
 
-        # We make assumptions here about the file name pattern that we don't
-        # exactly make elsewhere. We assume it has enough leading zeroes to
-        # always contain at least 3 digits, which is true for the data we
-        # are currently looking at, but might not always be true.
-        final_file_idx = self.skip_frames + (self.num_scans + 1) * np.prod(
-            self.scan_shape
-        )
+        newest = None
+        extra = 1
+        while True:
+            final_file_idx = self.skip_frames + (self.num_scans + extra) * scan_size
+            filename = f'{prefix}_{final_file_idx:03d}{suffix}'
+            filepath = self.dirpath / filename
+            if not filepath.exists():
+                break
+            newest = extra
+            newest_filepath = filepath
+            extra += 1
 
-        filename = f'{prefix}_{final_file_idx:03d}{suffix}'
-        return (self.dirpath / filename).exists()
+        if newest is None:
+            return None
+
+        # Verify the last file of the newest scan is fully written
+        # by attempting to open it. During fast acquisition, a file
+        # may exist on disk but not be fully written yet.
+        if not validate_image_file(newest_filepath):
+            newest -= 1
+            if newest == 0:
+                return None
+
+        return self.scan_start_number + self.num_scans + newest - 1
 
     def invalidate(self):
         self.file_prefix = None

--- a/polylaue/ui/main_window.py
+++ b/polylaue/ui/main_window.py
@@ -736,8 +736,13 @@ class MainWindow(QObject):
             self._live_acquisition_running = False
             return
 
-        # Add a new scan if one is available
-        self._add_new_scan_if_available()
+        # Add a new scan if one is available.
+        # Catch exceptions (e.g. partially-written files during fast
+        # acquisition) and retry on the next cycle.
+        try:
+            self._add_new_scan_if_available()
+        except Exception:
+            logger.debug('Live acquisition: error loading new scan, will retry')
 
         # Run the check again after the check gap time expires.
         QTimer.singleShot(
@@ -747,16 +752,21 @@ class MainWindow(QObject):
 
     def _add_new_scan_if_available(self):
         series = self.series
-        if series is None or not series.has_enough_data_for_new_scan:
-            # Can't add a new scan
+        if series is None:
+            return
+
+        newest = series.newest_available_scan_number
+        if newest is None:
+            # No new scans available
             return
 
         first_scan = series.scan_range_tuple[0]
-        new_final_scan = series.scan_range_tuple[1] + 1
-        series.scan_range_tuple = (first_scan, new_final_scan)
+        current_final = series.scan_range_tuple[1]
+        num_new = newest - current_final
+        series.scan_range_tuple = (first_scan, newest)
         series.self_validate(check_dark_file=False)
         self.save_project_manager()
-        self.on_shift_scan_number(1)
+        self.on_shift_scan_number(num_new)
 
     def on_action_include_advanced_structures_toggled(self):
         self.reflections_editor.include_advanced_structures = (

--- a/tests/test_live_acquisition.py
+++ b/tests/test_live_acquisition.py
@@ -1,0 +1,150 @@
+# Copyright © 2026, UChicago Argonne, LLC. See "LICENSE" for full details.
+
+from collections.abc import Iterable
+from pathlib import Path
+
+from PIL import Image
+
+from polylaue.model.project_manager import ProjectManager
+from polylaue.model.project import Project
+from polylaue.model.section import Section
+from polylaue.model.series import Series
+
+# A small valid TIF image, created once and reused for all test files.
+_SMALL_TIF = Image.new('L', (1, 1))
+
+
+def _create_files(dirpath: Path, prefix: str, indices: Iterable[int]) -> None:
+    """Create small valid .tif files with the given indices."""
+    for idx in indices:
+        _SMALL_TIF.save(dirpath / f'{prefix}_{idx:03d}.tif')
+
+
+def _make_series(
+    dirpath: Path,
+    scan_shape: tuple[int, int] = (2, 3),
+    skip_frames: int = 0,
+) -> Series:
+    """Create a minimal Series object pointing at dirpath."""
+    pm = ProjectManager()
+    project = Project(parent=pm, name='P')
+    pm.projects.append(project)
+    section = Section(parent=project, name='S')
+    project.sections.append(section)
+    series = Series(
+        parent=section,
+        name='Ser',
+        dirpath=str(dirpath),
+        scan_start_number=1,
+        scan_shape=scan_shape,
+        skip_frames=skip_frames,
+    )
+    section.series.append(series)
+    return series
+
+
+class TestLiveAcquisition:
+    """Tests for the live acquisition scan-detection properties."""
+
+    def test_newest_available_scan_number_none(self, tmp_path: Path) -> None:
+        """No new scan data → None."""
+        # scan_shape=(2,3) → 6 files per scan, skip_frames=0
+        # 1 scan needs files 001-006
+        _create_files(tmp_path, 'img', range(1, 7))
+        series = _make_series(tmp_path)
+        series.self_validate(check_dark_file=False)
+
+        assert series.num_scans == 1
+        assert series.newest_available_scan_number is None
+
+    def test_newest_available_scan_number_one_new(self, tmp_path: Path) -> None:
+        """Exactly one new scan available."""
+        # 1 existing scan (001-006) + 1 new (007-012)
+        _create_files(tmp_path, 'img', range(1, 13))
+        series = _make_series(tmp_path)
+        series.self_validate(check_dark_file=False)
+
+        assert series.newest_available_scan_number == 2
+
+    def test_newest_available_scan_number_multiple_new(self, tmp_path: Path) -> None:
+        """Three new scans available — should return the newest."""
+        # 1 existing scan (001-006) + 3 new scans (007-024)
+        _create_files(tmp_path, 'img', range(1, 25))
+        series = _make_series(tmp_path)
+        series.self_validate(check_dark_file=False)
+
+        assert series.newest_available_scan_number == 4
+
+    def test_newest_available_scan_number_partial_scan(self, tmp_path: Path) -> None:
+        """Two complete new scans + partial third → returns scan 3."""
+        # 1 existing (001-006) + 2 complete (007-018) + partial (019-020)
+        _create_files(tmp_path, 'img', range(1, 21))
+        series = _make_series(tmp_path)
+        series.self_validate(check_dark_file=False)
+
+        # Only 2 complete new scans, so newest is scan 3
+        assert series.newest_available_scan_number == 3
+
+    def test_jumps_to_newest(self, tmp_path: Path) -> None:
+        """Jump directly to the newest scan in one step."""
+        # Start with 1 scan, 3 new scans worth of data available
+        _create_files(tmp_path, 'img', range(1, 25))
+        series = _make_series(tmp_path)
+        series.self_validate(check_dark_file=False)
+
+        assert series.num_scans == 1
+        assert series.scan_range_tuple == (1, 1)
+
+        newest = series.newest_available_scan_number
+        assert newest == 4
+
+        first_scan = series.scan_range_tuple[0]
+        current_final = series.scan_range_tuple[1]
+        num_new = newest - current_final
+
+        series.scan_range_tuple = (first_scan, newest)
+        series.self_validate(check_dark_file=False)
+
+        # Jumped to scan 4 in a single step
+        assert num_new == 3
+        assert series.num_scans == 4
+        assert series.scan_range_tuple == (1, 4)
+
+    def test_with_skip_frames(self, tmp_path: Path) -> None:
+        """Verify newest_available_scan_number accounts for skip_frames."""
+        # skip_frames=2, scan_shape=(2,3)=6 files per scan
+        # Skipped files: 001, 002
+        # Scan 1: 003-008
+        # Scan 2 (new): 009-014
+        # File index for new scan check: 2 + (1+1)*6 = 14
+        _create_files(tmp_path, 'img', range(1, 15))
+        series = _make_series(tmp_path, skip_frames=2)
+        series.self_validate(check_dark_file=False)
+
+        assert series.num_scans == 1
+        assert series.newest_available_scan_number == 2
+
+    def test_newest_advances_as_files_arrive(self, tmp_path: Path) -> None:
+        """Simulate files arriving over time."""
+        # Start with just 1 scan
+        _create_files(tmp_path, 'img', range(1, 7))
+        series = _make_series(tmp_path)
+        series.self_validate(check_dark_file=False)
+
+        assert series.newest_available_scan_number is None
+
+        # Add files for 1 more scan
+        _create_files(tmp_path, 'img', range(7, 13))
+        assert series.newest_available_scan_number == 2
+
+        # Add files for 2 more scans at once (simulating fast acquisition)
+        _create_files(tmp_path, 'img', range(13, 25))
+        assert series.newest_available_scan_number == 4
+
+        # Jump to newest and verify
+        series.scan_range_tuple = (1, 4)
+        series.self_validate(check_dark_file=False)
+        assert series.num_scans == 4
+
+        # No more new scans
+        assert series.newest_available_scan_number is None


### PR DESCRIPTION
Previously, we would only load the next available scan. However, some setups (eg, scan shape of 1x1 collecting an image every 0.1 seconds) produces new scans at a very fast pace, and we couldn't keep up with it.

To keep up with it, we need to check for the newest scan available and skip to it, rather than iteratively loading each scan number in order.

This also adds a live acquisition test that tests the model portions of these things.