### PR TITLE
Significantly speed up live acquisition

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,3 @@
 [flake8]
 extend-ignore = E203
+max-line-length = 88

--- a/polylaue/model/io.py
+++ b/polylaue/model/io.py
@@ -30,9 +30,13 @@ def identify_loader_function(
 def validate_image_file(path: PathLike) -> bool:
     """Check whether an image file can be opened.
 
-    This is intentionally lightweight — it reads only the file header,
+    This is intentionally lightweight -- it reads only the file header,
     not the full pixel data.  Returns False for missing, empty, or
     partially-written files.
+
+    Thread-safety: called from the live-acquisition background thread.
+    Uses only the ``path`` argument and module-level constants
+    (``CUSTOM_VALIDATORS``); no shared mutable state is accessed.
     """
     extension = Path(path).suffix[1:]
     try:
@@ -121,7 +125,12 @@ def get_file_creation_time(filepath: PathLike) -> float:
 
 
 def _validate_tif_file(path: PathLike) -> None:
-    """Open a TIF header to verify the file is readable."""
+    """Open a TIF header to verify the file is readable.
+
+    Thread-safety: called from the live-acquisition background thread
+    (via ``validate_image_file``). Only operates on the given path;
+    no shared mutable state is accessed.
+    """
     import warnings
 
     with warnings.catch_warnings():
@@ -130,7 +139,12 @@ def _validate_tif_file(path: PathLike) -> None:
 
 
 def _validate_with_fabio(path: PathLike) -> None:
-    """Open a file with fabio to verify it is readable."""
+    """Open a file with fabio to verify it is readable.
+
+    Thread-safety: called from the live-acquisition background thread
+    (via ``validate_image_file``). Only operates on the given path;
+    no shared mutable state is accessed.
+    """
     import warnings
 
     with warnings.catch_warnings():

--- a/polylaue/model/series.py
+++ b/polylaue/model/series.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 import logging
+import os
 from pathlib import Path
 import re
 from typing import TYPE_CHECKING
@@ -293,7 +294,16 @@ class Series(Editable):
 
         Returns the scan number of the newest complete scan beyond the
         current set, or None if no new complete scan is available.
-        This needs to be fast because it's called during live acquisition.
+
+        A single ``os.listdir()`` call fetches every filename in one
+        network round-trip. After that, all checks are O(1) in-memory
+        set lookups, which is critical on slow network drives.
+
+        Thread-safety: called from the live-acquisition background
+        thread. Only *reads* attributes on ``self`` (``file_prefix``,
+        ``file_list``, ``scan_shape``, ``skip_frames``, ``num_scans``,
+        ``dirpath``). The caller must ensure no other thread is writing
+        to these attributes concurrently.
         """
         prefix = self.file_prefix
         if not prefix or not self.file_list:
@@ -303,16 +313,20 @@ class Series(Editable):
         suffix = Path(last_file).suffix
         scan_size = int(np.prod(self.scan_shape))
 
+        # One directory listing, then all checks are in-memory set lookups.
+        try:
+            dir_contents = set(os.listdir(self.dirpath))
+        except OSError:
+            return None
+
         newest = None
         extra = 1
         while True:
-            final_file_idx = self.skip_frames + (self.num_scans + extra) * scan_size
-            filename = f'{prefix}_{final_file_idx:03d}{suffix}'
-            filepath = self.dirpath / filename
-            if not filepath.exists():
+            idx = self.skip_frames + (self.num_scans + extra) * scan_size
+            filename = f'{prefix}_{idx:03d}{suffix}'
+            if filename not in dir_contents:
                 break
             newest = extra
-            newest_filepath = filepath
             extra += 1
 
         if newest is None:
@@ -321,12 +335,44 @@ class Series(Editable):
         # Verify the last file of the newest scan is fully written
         # by attempting to open it. During fast acquisition, a file
         # may exist on disk but not be fully written yet.
+        final_idx = self.skip_frames + (self.num_scans + newest) * scan_size
+        filename = f'{prefix}_{final_idx:03d}{suffix}'
+        newest_filepath = self.dirpath / filename
         if not validate_image_file(newest_filepath):
             newest -= 1
             if newest == 0:
                 return None
 
         return self.scan_start_number + self.num_scans + newest - 1
+
+    def extend_file_list(self, num_new_scans: int) -> None:
+        """Extend the file list for newly detected scans.
+
+        Constructs expected filenames from the known naming pattern
+        rather than re-listing the directory. This avoids the expensive
+        directory iterations that ``self_validate()`` performs.
+
+        Must be called after ``scan_range_tuple`` has already been
+        updated to include the new scans.
+        """
+        if not self.file_list or not self.file_prefix:
+            return
+
+        suffix = Path(self.file_list[-1]).suffix
+        scan_size = int(np.prod(self.scan_shape))
+
+        # scan_range_tuple was already updated, so num_scans includes
+        # the new scans. Compute the old file count from the geometry.
+        old_file_count = (self.num_scans - num_new_scans) * scan_size
+
+        # Trim any trailing entries beyond the previous scan range
+        # (e.g. from an initial self_validate that found extra files).
+        del self.file_list[old_file_count:]
+
+        for i in range(num_new_scans * scan_size):
+            idx = self.skip_frames + old_file_count + 1 + i
+            filename = f'{self.file_prefix}_{idx:03d}{suffix}'
+            self.file_list.append(filename)
 
     def invalidate(self):
         self.file_prefix = None

--- a/polylaue/ui/background_poller.py
+++ b/polylaue/ui/background_poller.py
@@ -1,0 +1,111 @@
+# Copyright © 2026, UChicago Argonne, LLC. See "LICENSE" for full details.
+
+import threading
+from typing import Callable
+
+from PySide6.QtCore import QObject, Signal
+
+
+class BackgroundPoller(QObject):
+    """Runs a callable on a background thread at regular intervals.
+
+    Emits ``result_ready`` with the return value of each successful
+    call, or ``check_error`` if the callable raises an exception.
+    Both signals are delivered on the main thread via Qt's queued
+    connections.
+
+    After receiving a result, the caller **must** call
+    ``notify_ready()`` to allow the next poll cycle.  This ensures the
+    target state being polled is not modified while the background
+    thread reads it.
+
+    Thread-safety: the callable passed to this poller must be safe to
+    call from a background thread.  See the ``_worker`` method for the
+    full synchronization protocol.
+    """
+
+    result_ready = Signal(object)
+    check_error = Signal()
+
+    def __init__(
+        self,
+        check_func: Callable,
+        interval_ms: int = 333,
+        parent: QObject | None = None,
+    ):
+        super().__init__(parent)
+        self._check_func = check_func
+        self._interval = interval_ms / 1000.0
+        self._thread: threading.Thread | None = None
+        self._stop = threading.Event()
+        # Set by the main thread after it finishes processing a result,
+        # telling the background thread it is safe to poll again.
+        self._ready = threading.Event()
+
+    @property
+    def is_running(self) -> bool:
+        return self._thread is not None and self._thread.is_alive()
+
+    def start(self) -> None:
+        """Start the background polling thread."""
+        if self.is_running:
+            return
+        self._stop.clear()
+        self._ready.set()  # Ready for the first poll
+        self._thread = threading.Thread(
+            target=self._worker,
+            daemon=True,
+            name="background-poller",
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Signal the background thread to stop."""
+        self._stop.set()
+        self._ready.set()  # Wake the thread if it is waiting
+
+    def notify_ready(self) -> None:
+        """Tell the background thread it may poll again.
+
+        Must be called by the main thread after it has finished
+        processing the previous result.
+        """
+        self._ready.set()
+
+    def _worker(self) -> None:
+        """Polling loop (runs on a dedicated background thread).
+
+        Thread-safety: calls ``_check_func`` which must be safe to call
+        from a background thread (read-only access to shared state).
+        Results are delivered to the main thread via Qt signals (queued
+        connections).
+
+        Synchronization protocol::
+
+            [BG] wait for _ready -> clear _ready -> call _check_func
+                 -> emit signal -> sleep
+            [Main] receive signal -> process result -> set _ready
+            [BG] (next iteration) wait for _ready -> ...
+
+        This guarantees the background thread never reads shared state
+        while the main thread is writing to it.
+        """
+        stop = self._stop
+        ready = self._ready
+
+        while not stop.is_set():
+            # Wait until the main thread signals it is safe to read.
+            while not ready.is_set() and not stop.is_set():
+                ready.wait(timeout=0.5)
+            if stop.is_set():
+                break
+            ready.clear()
+
+            try:
+                result = self._check_func()
+                self.result_ready.emit(result)
+            except Exception:
+                self.check_error.emit()
+
+            # Pause between polls.
+            stop.wait(timeout=self._interval)

--- a/polylaue/ui/main_window.py
+++ b/polylaue/ui/main_window.py
@@ -11,7 +11,6 @@ from PySide6.QtCore import (
     QEvent,
     QObject,
     QSettings,
-    QTimer,
     Qt,
 )
 from PySide6.QtGui import QIcon
@@ -46,6 +45,7 @@ from polylaue.ui.project_navigator.dialog import ProjectNavigatorDialog
 from polylaue.ui.region_mapping.dialog import RegionMappingDialog
 from polylaue.ui.regions_navigator.dialog import RegionsNavigatorDialog
 from polylaue.ui.track_dialog import TrackDialog
+from polylaue.ui.background_poller import BackgroundPoller
 from polylaue.ui.utils.ui_loader import UiLoader
 
 logger = logging.getLogger(__name__)
@@ -94,9 +94,10 @@ class MainWindow(QObject):
         self.show_mapping_highlight_area = False
         self.show_mapping_domain_area = False
 
-        self._live_acquisition_running = False
-        # Check every third of a second
-        self._live_acquisition_check_gap = 1 / 3
+        self._live_acq_poller = BackgroundPoller(
+            self._check_for_new_scans,
+            interval_ms=333,
+        )
 
         self.setup_connections()
 
@@ -130,6 +131,10 @@ class MainWindow(QObject):
         self.ui.action_enable_live_acquisition.toggled.connect(
             self.on_action_enable_live_acquisition_toggled
         )
+        self._live_acq_poller.result_ready.connect(
+            self._on_live_acquisition_check_result
+        )
+        self._live_acq_poller.check_error.connect(self._on_live_acquisition_check_error)
         self.ui.action_include_advanced_structures.toggled.connect(
             self.on_action_include_advanced_structures_toggled
         )
@@ -715,56 +720,60 @@ class MainWindow(QObject):
         self.image_view.on_mouse_move()
         self.set_mapping_dialogs_stale()
 
-    def on_action_enable_live_acquisition_toggled(self):
+    def on_action_enable_live_acquisition_toggled(self) -> None:
         if self.live_acquisition_enabled:
-            self.begin_live_acquisition()
+            self._live_acq_poller.start()
+        else:
+            self._live_acq_poller.stop()
 
-        # Live acquisition will end itself if disabled
+    def _check_for_new_scans(self) -> int | None:
+        """Return the newest available scan number, or None.
 
-    def begin_live_acquisition(self):
-        if self._live_acquisition_running:
-            # It's already running. No need to start it again.
-            return
+        Called from the ``BackgroundPoller`` thread. Must remain
+        thread-safe: only read from ``self.series`` attributes -- never
+        write. See ``BackgroundPoller._worker`` for the synchronization
+        protocol that prevents concurrent read/write access.
+        """
+        series = self.series
+        if series is None:
+            return None
+        return series.newest_available_scan_number
 
-        # Start the loop
-        self._live_acquisition_running = True
-        self._live_acquisition_loop()
+    def _on_live_acquisition_check_result(self, newest: int | None) -> None:
+        """Handle the result of a background scan check (main thread)."""
+        if newest is not None:
+            self._apply_new_scans(newest)
+        self._live_acq_poller.notify_ready()
 
-    def _live_acquisition_loop(self):
-        if not self.live_acquisition_enabled:
-            # It was disabled
-            self._live_acquisition_running = False
-            return
+    def _on_live_acquisition_check_error(self) -> None:
+        """Handle an error from the background scan check (main thread)."""
+        logger.debug('Live acquisition: error checking for new scans, will retry')
+        self._live_acq_poller.notify_ready()
 
-        # Add a new scan if one is available.
-        # Catch exceptions (e.g. partially-written files during fast
-        # acquisition) and retry on the next cycle.
-        try:
-            self._add_new_scan_if_available()
-        except Exception:
-            logger.debug('Live acquisition: error loading new scan, will retry')
+    def _apply_new_scans(self, newest: int) -> None:
+        """Update the series and display for newly detected scans (main thread).
 
-        # Run the check again after the check gap time expires.
-        QTimer.singleShot(
-            self._live_acquisition_check_gap,
-            self._live_acquisition_loop,
-        )
-
-    def _add_new_scan_if_available(self):
+        Modifies ``Series.scans``, ``Series.file_list``, and the UI.
+        The background thread must not be reading the Series while this
+        runs. That is guaranteed by the ``BackgroundPoller``
+        synchronization protocol: the poller waits for
+        ``notify_ready()`` before polling again.
+        """
         series = self.series
         if series is None:
             return
 
-        newest = series.newest_available_scan_number
-        if newest is None:
-            # No new scans available
+        current_final = series.scan_range_tuple[1]
+        if newest <= current_final:
+            # Already up to date (stale result from background thread)
             return
 
         first_scan = series.scan_range_tuple[0]
-        current_final = series.scan_range_tuple[1]
         num_new = newest - current_final
         series.scan_range_tuple = (first_scan, newest)
-        series.self_validate(check_dark_file=False)
+        # Extend the file list directly rather than calling
+        # self_validate(), which re-lists the entire directory.
+        series.extend_file_list(num_new)
         self.save_project_manager()
         self.on_shift_scan_number(num_new)
 

--- a/tests/test_find.py
+++ b/tests/test_find.py
@@ -35,7 +35,7 @@ def find_kwargs(
         'beam_dir': test_geometry['beam_dir'],
         'pix_dist': test_geometry['pix_dist'],
         'ang_tol': 0.07,
-        'res_lim': 0.4,
+        'res_lim': 0.6,
         'ref_thr': 3,
     }
 

--- a/tests/test_live_acquisition.py
+++ b/tests/test_live_acquisition.py
@@ -148,3 +148,63 @@ class TestLiveAcquisition:
 
         # No more new scans
         assert series.newest_available_scan_number is None
+
+    def test_extend_file_list(self, tmp_path: Path) -> None:
+        """extend_file_list adds correct filenames without re-listing dir."""
+        # 1 existing scan (001-006)
+        _create_files(tmp_path, 'img', range(1, 7))
+        series = _make_series(tmp_path)
+        series.self_validate(check_dark_file=False)
+
+        assert len(series.file_list) == 6
+        assert series.file_list[-1] == 'img_006.tif'
+
+        # Simulate detecting 2 new scans via extend_file_list
+        series.scan_range_tuple = (1, 3)
+        series.extend_file_list(2)
+
+        assert len(series.file_list) == 18
+        assert series.file_list[6] == 'img_007.tif'
+        assert series.file_list[-1] == 'img_018.tif'
+
+    def test_extend_file_list_with_skip_frames(self, tmp_path: Path) -> None:
+        """extend_file_list accounts for skip_frames in indices."""
+        # skip_frames=2, scan_shape=(2,3)=6 files per scan
+        # Scan 1: 003-008
+        _create_files(tmp_path, 'img', range(1, 9))
+        series = _make_series(tmp_path, skip_frames=2)
+        series.self_validate(check_dark_file=False)
+
+        assert len(series.file_list) == 6
+        assert series.file_list[0] == 'img_003.tif'
+
+        # Extend by 1 scan: new files should be 009-014
+        series.scan_range_tuple = (1, 2)
+        series.extend_file_list(1)
+
+        assert len(series.file_list) == 12
+        assert series.file_list[6] == 'img_009.tif'
+        assert series.file_list[-1] == 'img_014.tif'
+
+    def test_extend_file_list_matches_self_validate(self, tmp_path: Path) -> None:
+        """extend_file_list produces the same list as self_validate."""
+        # Start with exactly 1 scan (like a real acquisition start)
+        _create_files(tmp_path, 'img', range(1, 7))
+        series = _make_series(tmp_path)
+        series.self_validate(check_dark_file=False)
+        assert len(series.file_list) == 6
+
+        # Files for 3 more scans arrive
+        _create_files(tmp_path, 'img', range(7, 25))
+
+        # Build a reference via self_validate with the full range
+        ref_series = _make_series(tmp_path)
+        ref_series.scan_range_tuple = (1, 4)
+        ref_series.self_validate(check_dark_file=False)
+        expected = list(ref_series.file_list)
+
+        # Now use extend_file_list on the original series
+        series.scan_range_tuple = (1, 4)
+        series.extend_file_list(3)
+
+        assert series.file_list == expected


### PR DESCRIPTION
This is important for 1x1 scans that acquire images at a high pace (such as 10 frames per second).

Because the data must often be accessed through a network drive, we needed to reduce file I/O operations and move checking to a background thread.

This ought to be much faster for performing live acquisition through a network drive.