### PR TITLE
Various Improvements

### DIFF
--- a/polylaue/model/core/find.py
+++ b/polylaue/model/core/find.py
@@ -187,6 +187,8 @@ def find(
                 'Combinations of primary and secondary vectors:',
                 np.shape(hkl_sec)[0],
             )
+            if np.shape(hkl_sec)[0] == 0:
+                continue
             print('J. Appl. Phys., Vol. 86, No. 9, 1 November 1999, 5249-5255')
             hkl_axi1 = hkl_pri
             obs_axi1 = obs_pri

--- a/polylaue/model/core/track.py
+++ b/polylaue/model/core/track.py
@@ -218,6 +218,8 @@ def track(
     hkl_pri = hkl_pri[vec_sel[0], :]
     hkl_sec = hkl_sec[vec_sel[0], :]
     print('Combinations of primary and secondary vectors:', np.shape(hkl_sec)[0])
+    if np.shape(hkl_sec)[0] == 0:
+        return None, None
     print('J. Appl. Phys., Vol. 86, No. 9, 1 November 1999, 5249-5255')
     hkl_axi1 = hkl_pri
     obs_axi1 = obs_pri

--- a/polylaue/model/project.py
+++ b/polylaue/model/project.py
@@ -44,6 +44,8 @@ class Project(Editable):
         self.description = description
         self.energy_range = energy_range
         self.frame_shape = frame_shape
+        # white_beam_shift is currently unused in the UI, but retained
+        # for potential future use in geometry calculations.
         self.white_beam_shift = white_beam_shift
         self.min_find_resolution = min_find_resolution
         self.min_tracking_resolution = min_tracking_resolution
@@ -195,12 +197,6 @@ class Project(Editable):
                 'min': 1e-16,
                 'max': float('inf'),
                 'tooltip': 'The energy range of the x-ray beam in keV',
-            },
-            'white_beam_shift': {
-                'type': 'float',
-                'label': 'Beam Shift',
-                'min': 1e-16,
-                'max': float('inf'),
             },
             'geometry_path_str': {
                 'type': 'file',

--- a/polylaue/ui/burn_dialog.py
+++ b/polylaue/ui/burn_dialog.py
@@ -18,6 +18,7 @@ class BurnDialog(QObject):
     update_has_angular_shift = Signal()
     write_crystal_orientation = Signal()
     clear_reflections = Signal()
+    save_as_new_crystal = Signal()
 
     def __init__(self, include_advanced_structures: bool, parent=None):
         super().__init__(parent)
@@ -91,6 +92,7 @@ class BurnDialog(QObject):
             self.on_use_custom_internal_abc_matrix_toggled
         )
 
+        self.ui.save_as_new_crystal.clicked.connect(self.on_save_as_new_crystal_clicked)
         self.ui.clear.clicked.connect(self.on_clear_clicked)
 
     def update_enable_states(self):
@@ -107,6 +109,11 @@ class BurnDialog(QObject):
         self.ui.write_crystal_orientation.setEnabled(not using_custom_matrix)
 
         self.ui.angular_shift_group.setEnabled(not using_custom_matrix)
+
+        can_save_new = (
+            self._custom_internal_abc_matrix is not None or self.apply_angular_shift
+        )
+        self.ui.save_as_new_crystal.setEnabled(can_save_new)
 
     def activate_burn(self):
         self.burn_activated = True
@@ -266,6 +273,8 @@ class BurnDialog(QObject):
             'Use a custom internal ABC matrix. ' f'The current one is:\n\n{abc_matrix}'
         )
 
+        self.update_enable_states()
+
     def on_activate_burn(self):
         self.emit_if_active()
 
@@ -275,6 +284,8 @@ class BurnDialog(QObject):
     def on_crystal_id_changed(self):
         # Deactivate the burn function
         self.deactivate_burn()
+
+        self.custom_internal_abc_matrix = None
 
         # Load the crystal name
         self.load_crystal_name.emit()
@@ -329,6 +340,7 @@ class BurnDialog(QObject):
             # Make sure the angular shift from another crystal is disabled
             self.angular_shift_from_another_crystal = False
 
+        self.update_enable_states()
         self.emit_if_active()
 
     def on_angular_shift_from_another_crystal_changed(self):
@@ -353,6 +365,9 @@ class BurnDialog(QObject):
             return
 
         self.burn_triggered.emit()
+
+    def on_save_as_new_crystal_clicked(self):
+        self.save_as_new_crystal.emit()
 
     def on_clear_clicked(self):
         self.deactivate_burn()

--- a/polylaue/ui/burn_workflow.py
+++ b/polylaue/ui/burn_workflow.py
@@ -1,5 +1,6 @@
 # Copyright © 2026, UChicago Argonne, LLC. See "LICENSE" for full details.
 
+import re
 from pathlib import Path
 
 from PySide6.QtCore import QObject, QSettings, Qt, Signal
@@ -178,6 +179,7 @@ class BurnWorkflow(QObject):
         dialog.update_has_angular_shift.connect(self.update_has_angular_shift)
         dialog.overwrite_crystal.connect(self.overwrite_crystal)
         dialog.write_crystal_orientation.connect(self.write_crystal_orientation)
+        dialog.save_as_new_crystal.connect(self.save_as_new_crystal)
         self.burn_dialog.clear_reflections.connect(self.clear_reflections)
         self.load_crystal_name()
         self.update_has_angular_shift()
@@ -442,6 +444,74 @@ class BurnWorkflow(QObject):
             box.exec_()
             if cb.isChecked():
                 settings.setValue(skip_message_key, True)
+
+    def save_as_new_crystal(self):
+        self.load_abc_matrix()
+        if self.abc_matrix is None:
+            QMessageBox.critical(
+                None,
+                'No ABC Matrix',
+                'Failed to load the ABC matrix. Cannot save.',
+            )
+            return
+
+        old_name = self.burn_dialog.crystal_name
+
+        # Clear reflections for the old crystal ID on the current frame,
+        # since they were burned with a modified matrix.
+        self.clear_reflections()
+
+        reflections = self.reflections
+        new_crystal_id = reflections.num_crystals
+
+        crystals_table = reflections.crystals_table
+        if crystals_table.size == 0:
+            crystals_table = np.zeros((1, 9))
+            crystals_table[0] = self.abc_matrix
+        else:
+            crystals_table = np.vstack((crystals_table, self.abc_matrix))
+
+        reflections.crystals_table = crystals_table
+        reflections.set_crystal_scan_number(new_crystal_id, self.scan_num)
+
+        self.burn_dialog.crystal_id = new_crystal_id
+        self.burn_dialog.set_crystal_orientation_to_hdf5_file()
+        self.burn_dialog.apply_angular_shift = False
+        self.burn_dialog.custom_internal_abc_matrix = None
+        self.burn_dialog.use_custom_internal_abc_matrix = False
+
+        new_name = self._unique_crystal_name(old_name)
+        self.burn_dialog.crystal_name = new_name
+        self.write_crystal_name()
+
+        self.burn_dialog.activate_burn()
+
+        msg = (
+            f'Saved as new crystal with ID {new_crystal_id} '
+            f'(scan number {self.scan_num}).'
+        )
+        QMessageBox.information(None, 'Crystal Saved', msg)
+
+    def _unique_crystal_name(self, name: str) -> str:
+        if not name:
+            return ''
+
+        match = re.match(r'^(.*) \((\d+)\)$', name)
+        if match:
+            base = match.group(1)
+            start = int(match.group(2)) + 1
+        else:
+            base = name
+            start = 2
+
+        existing = {n.decode() for n in self.reflections.crystal_names}
+
+        num = start
+        while True:
+            candidate = f'{base} ({num})'
+            if candidate not in existing:
+                return candidate
+            num += 1
 
     def clear_reflections(self):
         # Delete any reflections matching the currently selected crystal ID

--- a/polylaue/ui/burn_workflow.py
+++ b/polylaue/ui/burn_workflow.py
@@ -166,6 +166,7 @@ class BurnWorkflow(QObject):
             crystals_table = np.vstack((crystals_table, self.abc_matrix))
 
         self.reflections.crystals_table = crystals_table
+        self.reflections.set_crystal_scan_number(self.crystal_id, self.scan_num)
 
     def show_burn_dialog(self):
         if self.burn_dialog:
@@ -403,6 +404,7 @@ class BurnWorkflow(QObject):
         # Otherwise, we'll overwrite the crystal!
         crystals_table[crystal_id] = self.abc_matrix
         self.reflections.crystals_table = crystals_table
+        self.reflections.set_crystal_scan_number(crystal_id, self.scan_num)
 
     def write_crystal_orientation(self):
         self.load_abc_matrix()

--- a/polylaue/ui/hkl_regions_navigator/dialog.py
+++ b/polylaue/ui/hkl_regions_navigator/dialog.py
@@ -357,7 +357,7 @@ class HklRegionsNavigatorDialog(QDialog):
         # Reset color of previously selected roi, if any
         roi_item = self.roi_items_manager.roi_items.get(self.selected_roi_id)
         if roi_item is not None:
-            roi_item.pen.setColor(Qt.white)
+            roi_item.pen.setColor(Qt.cyan)
             roi_item.update()
 
         if current.count() > 0:

--- a/polylaue/ui/hkl_regions_navigator/model.py
+++ b/polylaue/ui/hkl_regions_navigator/model.py
@@ -85,8 +85,6 @@ class RegionsNavigatorModel(QAbstractTableModel):
                 return float(roi['size'][0])
             elif col == SIZE_Y_COL:
                 return float(roi['size'][1])
-        elif role == Qt.ItemDataRole.FontRole:
-            return QBrush(Qt.GlobalColor.green)
         elif role == Qt.ItemDataRole.BackgroundRole:
             id = self.roi_manager.index_to_id(index.row())
             roi = self.roi_manager.get_roi(id)
@@ -149,7 +147,7 @@ class RegionsNavigatorModel(QAbstractTableModel):
                 id, new_crystal_id, new_hkl, new_position, new_size
             )
 
-            self.dataChanged.emit(index, index, role)
+            self.dataChanged.emit(index, index, [role])
 
             return True
 
@@ -218,4 +216,4 @@ class RegionsNavigatorModel(QAbstractTableModel):
         self.roi_manager.update_roi(id, crystal_id, hkl, position, size)
         top_left = self.createIndex(row, H_COL)
         bottom_right = self.createIndex(row, SIZE_Y_COL)
-        self.dataChanged.emit(top_left, bottom_right, Qt.EditRole)
+        self.dataChanged.emit(top_left, bottom_right, [Qt.EditRole])

--- a/polylaue/ui/region_mapping/grid_item.py
+++ b/polylaue/ui/region_mapping/grid_item.py
@@ -122,7 +122,7 @@ class CustomGridItem(pg.GraphicsObject):
             len(self.x_ticks) > self.active_cell[0] + 1
             and len(self.y_ticks) > self.active_cell[1] + 1
         ):
-            p.setPen(pg.mkPen('y', width=2))
+            p.setPen(pg.mkPen('c', width=4))
 
             x0 = self.x_ticks[self.active_cell[0]]
             y0 = self.y_ticks[self.active_cell[1]]

--- a/polylaue/ui/regions_navigator/dialog.py
+++ b/polylaue/ui/regions_navigator/dialog.py
@@ -364,7 +364,7 @@ class RegionsNavigatorDialog(QDialog):
         # Reset color of previously selected roi, if any
         roi_item = self.roi_items_manager.roi_items.get(self.selected_roi_id)
         if roi_item is not None:
-            roi_item.pen.setColor(Qt.white)
+            roi_item.pen.setColor(Qt.cyan)
             roi_item.update()
 
         if current.count() > 0:

--- a/polylaue/ui/regions_navigator/model.py
+++ b/polylaue/ui/regions_navigator/model.py
@@ -93,7 +93,7 @@ class RegionsNavigatorModel(QAbstractTableModel):
 
             self.roi_manager.update_roi(id, new_pos, new_size)
 
-            self.dataChanged.emit(index, index, role)
+            self.dataChanged.emit(index, index, [role])
 
             return True
 
@@ -147,4 +147,4 @@ class RegionsNavigatorModel(QAbstractTableModel):
         self.roi_manager.update_roi(id, position, size)
         top_left = self.createIndex(row, 1)
         bottom_right = self.createIndex(row, 4)
-        self.dataChanged.emit(top_left, bottom_right, Qt.EditRole)
+        self.dataChanged.emit(top_left, bottom_right, [Qt.EditRole])

--- a/polylaue/ui/resources/ui/burn_dialog.ui
+++ b/polylaue/ui/resources/ui/burn_dialog.ui
@@ -290,7 +290,7 @@
          <string>Apply Angular Shift</string>
         </property>
         <property name="checked">
-         <bool>true</bool>
+         <bool>false</bool>
         </property>
        </widget>
       </item>

--- a/polylaue/ui/resources/ui/burn_dialog.ui
+++ b/polylaue/ui/resources/ui/burn_dialog.ui
@@ -7,60 +7,20 @@
     <x>0</x>
     <y>0</y>
     <width>460</width>
-    <height>707</height>
+    <height>725</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Burn Reflections</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0" colspan="2">
-    <layout class="QGridLayout" name="gridLayout_3">
-     <item row="0" column="1">
-      <widget class="QCheckBox" name="activate_burn">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Activate the burn function, so that when the dmin slider or structure type is edited, burn is triggered.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If the crystal ID changes, or the current frame changes, burn is automatically deactivated in order to prevent any accidental overwriting of previously burned reflections.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="styleSheet">
-        <string notr="true">Q</string>
-       </property>
-       <property name="text">
-        <string>Activate Burn</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="0" column="2">
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
-   <item row="2" column="1">
-    <widget class="QComboBox" name="structure_type">
+   <item row="10" column="0" colspan="2">
+    <widget class="QPushButton" name="clear">
      <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the structure type used when burning reflections.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Clear reflections matching the currently selected crystal ID in the HDF5 file for the currently viewed frame.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Clear Reflections</string>
      </property>
     </widget>
    </item>
@@ -74,164 +34,11 @@
      </property>
     </widget>
    </item>
-   <item row="9" column="0" colspan="2">
-    <widget class="QPushButton" name="clear">
+   <item row="2" column="1">
+    <widget class="QComboBox" name="structure_type">
      <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Clear reflections matching the currently selected crystal ID in the HDF5 file for the currently viewed frame.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the structure type used when burning reflections.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
-     <property name="text">
-      <string>Clear Reflections</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0" colspan="2">
-    <widget class="QGroupBox" name="angular_shift_group">
-     <property name="title">
-      <string>Angular Shift</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_5">
-      <item row="0" column="0">
-       <widget class="QCheckBox" name="apply_angular_shift">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Apply angular shift to the ABC Matrix.&lt;/p&gt;&lt;p&gt;If checked, the selected crystal ID must have angular shifts for this scan number stored in the reflections HDF5 file. These angular shifts are typically generated using &amp;quot;Indexing&amp;quot; -&amp;gt; &amp;quot;Select Points&amp;quot; -&amp;gt; &amp;quot;Refinement&amp;quot;, to perform crystal orientation tracking.&lt;/p&gt;&lt;p&gt;If this checkbox is disabled, that indicates there are no angular shifts for this scan number in the reflections HDF5 file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-         <string>Apply Angular Shift</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="angular_shift_from_another_crystal">
-        <property name="text">
-         <string>From another crystal?</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QSpinBox" name="angular_shift_crystal_id">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="maximum">
-         <number>10000000</number>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLabel" name="has_angular_shift_label">
-        <property name="text">
-         <string>Has angular shift:</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="2">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="6" column="0" colspan="2">
-    <widget class="QGroupBox" name="min_d_spacing_group">
-     <property name="title">
-      <string>Min d-spacing</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="0" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="ScientificDoubleSpinBox" name="max_dmin">
-          <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Maximum value for the burn slider.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="keyboardTracking">
-           <bool>false</bool>
-          </property>
-          <property name="decimals">
-           <number>8</number>
-          </property>
-          <property name="maximum">
-           <double>100000.000000000000000</double>
-          </property>
-          <property name="value">
-           <double>1.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QSlider" name="dmin_slider">
-          <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The burn slider. Edit this to visualize changes in predicted reflections.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="maximum">
-           <number>100</number>
-          </property>
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="min_dmin">
-          <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The minimum value for the burn slider is always 0.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="text">
-           <string>0.0</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="1" column="1">
-       <widget class="ScientificDoubleSpinBox" name="dmin_value">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The current value of the burn slider.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="keyboardTracking">
-         <bool>false</bool>
-        </property>
-        <property name="decimals">
-         <number>8</number>
-        </property>
-        <property name="maximum">
-         <double>100000.000000000000000</double>
-        </property>
-        <property name="value">
-         <double>1.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Value:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Slider:</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
     </widget>
    </item>
    <item row="3" column="0" colspan="2">
@@ -321,6 +128,199 @@
      </layout>
     </widget>
    </item>
+   <item row="1" column="0" colspan="2">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <layout class="QGridLayout" name="gridLayout_3">
+     <item row="0" column="1">
+      <widget class="QCheckBox" name="activate_burn">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Activate the burn function, so that when the dmin slider or structure type is edited, burn is triggered.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If the crystal ID changes, or the current frame changes, burn is automatically deactivated in order to prevent any accidental overwriting of previously burned reflections.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">Q</string>
+       </property>
+       <property name="text">
+        <string>Activate Burn</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="0" column="2">
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="6" column="0" colspan="2">
+    <widget class="QGroupBox" name="min_d_spacing_group">
+     <property name="title">
+      <string>Min d-spacing</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="ScientificDoubleSpinBox" name="max_dmin">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Maximum value for the burn slider.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="keyboardTracking">
+           <bool>false</bool>
+          </property>
+          <property name="decimals">
+           <number>8</number>
+          </property>
+          <property name="maximum">
+           <double>100000.000000000000000</double>
+          </property>
+          <property name="value">
+           <double>1.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSlider" name="dmin_slider">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The burn slider. Edit this to visualize changes in predicted reflections.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="maximum">
+           <number>100</number>
+          </property>
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="min_dmin">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The minimum value for the burn slider is always 0.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>0.0</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="1" column="1">
+       <widget class="ScientificDoubleSpinBox" name="dmin_value">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The current value of the burn slider.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="decimals">
+         <number>8</number>
+        </property>
+        <property name="maximum">
+         <double>100000.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>1.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Value:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Slider:</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="2">
+    <widget class="QGroupBox" name="angular_shift_group">
+     <property name="title">
+      <string>Angular Shift</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_5">
+      <item row="0" column="0">
+       <widget class="QCheckBox" name="apply_angular_shift">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Apply angular shift to the ABC Matrix.&lt;/p&gt;&lt;p&gt;If checked, the selected crystal ID must have angular shifts for this scan number stored in the reflections HDF5 file. These angular shifts are typically generated using &amp;quot;Indexing&amp;quot; -&amp;gt; &amp;quot;Select Points&amp;quot; -&amp;gt; &amp;quot;Refinement&amp;quot;, to perform crystal orientation tracking.&lt;/p&gt;&lt;p&gt;If this checkbox is disabled, that indicates there are no angular shifts for this scan number in the reflections HDF5 file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Apply Angular Shift</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="angular_shift_from_another_crystal">
+        <property name="text">
+         <string>From another crystal?</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QSpinBox" name="angular_shift_crystal_id">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="maximum">
+         <number>10000000</number>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="has_angular_shift_label">
+        <property name="text">
+         <string>Has angular shift:</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
    <item row="8" column="0" colspan="2">
     <widget class="QCheckBox" name="use_custom_internal_abc_matrix">
      <property name="enabled">
@@ -331,6 +331,19 @@
      </property>
      <property name="text">
       <string>Use Custom Internal ABC Matrix</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0" colspan="2">
+    <widget class="QPushButton" name="save_as_new_crystal">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Save the current ABC matrix used for &amp;quot;Burn&amp;quot; as a new crystal in the HDF5 reflections file. This creates a new crystal ID using the current stored/computed orientation.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;This can be useful, for instance, for identifying split crystals.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Save as New Crystal</string>
      </property>
     </widget>
    </item>
@@ -358,6 +371,7 @@
   <tabstop>angular_shift_from_another_crystal</tabstop>
   <tabstop>angular_shift_crystal_id</tabstop>
   <tabstop>use_custom_internal_abc_matrix</tabstop>
+  <tabstop>save_as_new_crystal</tabstop>
   <tabstop>clear</tabstop>
  </tabstops>
  <resources/>


### PR DESCRIPTION
* Guard against 0 combinations in find() and track() to prevent error messages when no valid primary/secondary vector    
  combinations exist
* Remove "Beam Shift" field from Project Editor settings (geometry in geosetup.npz is already corrected by this shift)
* Use cyan instead of white/yellow for region outlines to improve visibility on the thermal reverse intensity scale
* Add "Save as New Crystal" button to the Burn dialog, allowing split crystal orientations (from angular shift or custom matrix) to be saved as new crystal entries in the HDF5 table. Copies the crystal name with a unique suffix, clears old reflections on the current frame, and immediately activates burn for the new crystal.
* Default "Apply Angular Shift" to unchecked in the Burn dialog
* Set crystal scan number when writing a crystal to the HDF5 table via "Overwrite Crystal in Reflections File" or implicit creation during burn, fixing a bug where Track/Refine would reject these crystals
* Clear custom internal ABC matrix when switching crystal IDs in the Burn dialog